### PR TITLE
URL Cleanup

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -16,5 +16,5 @@ unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 == License
 Spring Dsl is Open Source software released under the
-http://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
+https://www.apache.org/licenses/LICENSE-2.0.html[Apache 2.0 license].
 

--- a/docs/src/info/license.txt
+++ b/docs/src/info/license.txt
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrCompletionEngine.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrCompletionEngine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrCompletionResult.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrCompletionResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrFactory.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrParseResult.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrParseResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrParseService.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/AntlrParseService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrCompletioner.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrCompletioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrDslService.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrDslService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrErrorListener.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrErrorListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrHoverer.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrHoverer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrLinter.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrLinter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrParseResultFunction.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrParseResultFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrSymbolizer.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrSymbolizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AntlrObjectSupport.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AntlrObjectSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AntlrUtils.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AntlrUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/DefaultAntlrCompletionEngine.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/DefaultAntlrCompletionEngine.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/DefaultAntlrParseService.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/DefaultAntlrParseService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrCompletionerTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrCompletionerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrHovererTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrHovererTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrLinterTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrLinterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrSymbolizerTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrSymbolizerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrCompletioner.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrCompletioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrHoverer.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrHoverer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrLinter.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrLinter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrParseResultFunction.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrParseResultFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrSymbolizer.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2AntlrSymbolizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2ErrorListener.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2ErrorListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2Visitor.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/Test2Visitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/TestAntrlUtils.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/TestAntrlUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/TestResourceUtils.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/TestResourceUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/support/DefaultAntlrCompletionEngineTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/support/DefaultAntlrCompletionEngineTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/support/DefaultAntlrParseServiceTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/support/DefaultAntlrParseServiceTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/DslAutoConfiguration.java
+++ b/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/DslAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LanguageServerControllerAutoConfiguration.java
+++ b/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LanguageServerControllerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LspClientAutoConfiguration.java
+++ b/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LspClientAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LspServerAutoConfiguration.java
+++ b/spring-dsl-autoconfigure/src/main/java/org/springframework/dsl/autoconfigure/LspServerAutoConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-autoconfigure/src/test/java/org/springframework/dsl/autoconfigure/LspServerAutoConfigurationTests.java
+++ b/spring-dsl-autoconfigure/src/test/java/org/springframework/dsl/autoconfigure/LspServerAutoConfigurationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-build-tests/src/test/java/org/springframework/dsl/buildtests/AbstractLspIntegrationTests.java
+++ b/spring-dsl-build-tests/src/test/java/org/springframework/dsl/buildtests/AbstractLspIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-build-tests/src/test/java/org/springframework/dsl/buildtests/LspNettySocketLspServerIntegrationTests.java
+++ b/spring-dsl-build-tests/src/test/java/org/springframework/dsl/buildtests/LspNettySocketLspServerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/DslException.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/DslException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/DslParser.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/DslParser.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/DslParserResult.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/DslParserResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/DslSystemConstants.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/DslSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/BadLocationException.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/BadLocationException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/Document.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/Document.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/DocumentRegion.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/DocumentRegion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/TextDocument.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/TextDocument.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/AbstractLineTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/AbstractLineTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/DefaultLineTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/DefaultLineTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/DefaultRegion.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/DefaultRegion.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/Line.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/Line.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/LineTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/LineTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/ListLineTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/ListLineTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/Region.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/Region.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/TreeLineTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/document/linetracker/TreeLineTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ClientCapabilities.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ClientCapabilities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Command.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Command.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionContext.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionContext.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionItem.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionItemKind.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionItemKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionList.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionList.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionOptions.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionTriggerKind.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/CompletionTriggerKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Diagnostic.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Diagnostic.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DiagnosticSeverity.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DiagnosticSeverity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidChangeTextDocumentParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidChangeTextDocumentParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidCloseTextDocumentParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidCloseTextDocumentParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidOpenTextDocumentParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidOpenTextDocumentParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidSaveTextDocumentParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DidSaveTextDocumentParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DocumentSymbol.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DocumentSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DocumentSymbolParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DocumentSymbolParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DynamicRegistration.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/DynamicRegistration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Hover.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Hover.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializeParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializeParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializeResult.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializeResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializedParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InitializedParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InsertTextFormat.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/InsertTextFormat.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Location.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Location.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/LogMessageParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/LogMessageParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkedString.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkedString.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkupContent.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkupContent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkupKind.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MarkupKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageActionItem.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageActionItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageType.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/MessageType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Position.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Position.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/PublishDiagnosticsParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/PublishDiagnosticsParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Range.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Range.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Registration.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Registration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/RegistrationParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/RegistrationParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/RenameParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/RenameParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SaveOptions.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SaveOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ServerCapabilities.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ServerCapabilities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ShowMessageRequestParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/ShowMessageRequestParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SymbolInformation.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SymbolInformation.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SymbolKind.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/SymbolKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Synchronization.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Synchronization.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentClientCapabilities.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentClientCapabilities.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentContentChangeEvent.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentContentChangeEvent.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentEdit.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentEdit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentIdentifier.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentIdentifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentItem.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentItem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentPositionParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentPositionParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSaveReason.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSaveReason.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSyncKind.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSyncKind.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSyncOptions.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextDocumentSyncOptions.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextEdit.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/TextEdit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Unregistration.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/Unregistration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/VersionedTextDocumentIdentifier.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/VersionedTextDocumentIdentifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/WillSaveTextDocumentParams.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/WillSaveTextDocumentParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/domain/WorkspaceEdit.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/domain/WorkspaceEdit.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/model/LanguageId.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/model/LanguageId.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/model/TrackedDocument.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/model/TrackedDocument.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/AbstractDslService.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/AbstractDslService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/Completioner.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/Completioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DefaultDocumentStateTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DefaultDocumentStateTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DefaultDslServiceRegistry.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DefaultDslServiceRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DocumentStateTracker.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DocumentStateTracker.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslService.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslServiceRegistry.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslServiceRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/Hoverer.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/Hoverer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/Renamer.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/Renamer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DefaultDocumentService.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DefaultDocumentService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DocumentService.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DocumentService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DocumentServiceHandler.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/document/DocumentServiceHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconcileProblem.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconcileProblem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconciler.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconciler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Linter.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Linter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemSeverity.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemSeverity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemType.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemTypes.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ProblemTypes.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ReconcileProblem.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/ReconcileProblem.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Reconciler.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Reconciler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/symbol/SymbolizeInfo.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/symbol/SymbolizeInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/symbol/Symbolizer.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/symbol/Symbolizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/support/AbstractDomainBuilder.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/support/AbstractDomainBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/support/DomainBuilder.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/support/DomainBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/support/DslUtils.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/support/DslUtils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/CompletionDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/CompletionDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/CoreDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/CoreDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/DomainClassesDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/DomainClassesDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/HoverDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/HoverDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/ReconcileDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/ReconcileDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/RenameDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/RenameDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/SymbolDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/SymbolDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/document/DocumentRegionTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/document/DocumentRegionTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/document/TextDocumentTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/document/TextDocumentTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/model/LanguageIdTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/model/LanguageIdTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/service/DefaultDocumentStateTrackerTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/service/DefaultDocumentStateTrackerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/service/reconcile/DefaultReconcilerTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/service/reconcile/DefaultReconcilerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerAdapter.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerMapping.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerResult.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerResultHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcHandlerResultHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcInputMessage.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcInputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcMessage.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcOutputMessage.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcOutputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcRequest.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcResponse.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcSystemConstants.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/JsonRpcSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/ServerJsonRpcExchange.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/ServerJsonRpcExchange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcController.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcNotification.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcNotification.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcRequestMapping.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcRequestMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcRequestParams.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcRequestParams.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcResponseResult.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/annotation/JsonRpcResponseResult.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/DefaultJsonRpcExtractorStrategiesBuilder.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/DefaultJsonRpcExtractorStrategiesBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/Jackson2JsonRpcMessageWriter.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/Jackson2JsonRpcMessageWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractor.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractorStrategies.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractorStrategies.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcMessageWriter.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/codec/JsonRpcMessageWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/DelegatingJsonRpcConfiguration.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/DelegatingJsonRpcConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/EnableJsonRpc.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/EnableJsonRpc.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/JsonRpcJacksonConfiguration.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/config/JsonRpcJacksonConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperBuilder.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperBuilderCustomizer.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperBuilderCustomizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperFactoryBean.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/jackson/JsonRpcJackson2ObjectMapperFactoryBean.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/HandlerResultHandlerSupport.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/HandlerResultHandlerSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/AbstractRequestCondition.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/AbstractRequestCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/JsonRcpRequestMethodsRequestCondition.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/JsonRcpRequestMethodsRequestCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/JsonRpcRequestCondition.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/condition/JsonRpcRequestCondition.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/AbstractHandlerMethodMapping.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/AbstractHandlerMethodMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/HandlerMethod.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/HandlerMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/InvocableHandlerMethod.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/InvocableHandlerMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcHandlerMethodArgumentResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcHandlerMethodArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcMethodParamsArgumentResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcMethodParamsArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcRequestMappingInfo.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcRequestMappingInfo.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcRequestParamsArgumentResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/JsonRpcRequestParamsArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/AbstractMessageWriterResultHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/AbstractMessageWriterResultHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcNotificationResultHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcNotificationResultHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerAdapter.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerMapping.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerMapping.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcResponseResultResultHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcResponseResultResultHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/ServerJsonRpcExchangeArgumentResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/result/method/annotation/ServerJsonRpcExchangeArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/DefaultJsonRpcSessionManager.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/DefaultJsonRpcSessionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/InMemoryJsonRpcSessionStore.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/InMemoryJsonRpcSessionStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSession.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSession.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionIdResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionIdResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionManager.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionStore.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/JsonRpcSessionStore.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/RequestSessionIdJsonRpcSessionIdResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/session/RequestSessionIdJsonRpcSessionIdResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/AbstractJsonRpcObject.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/AbstractJsonRpcObject.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/AbstractJsonRpcOutputMessage.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/AbstractJsonRpcOutputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/ChannelSendOperator.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/ChannelSendOperator.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/ControllerMethodResolver.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/ControllerMethodResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcRequest.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcRequest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcRequestJsonDeserializer.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcRequestJsonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcResponse.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcResponseJsonDeserializer.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultJsonRpcResponseJsonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultServerJsonRpcExchange.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DefaultServerJsonRpcExchange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DispatcherJsonRpcHandler.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/DispatcherJsonRpcHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/JsonRpcRequestJsonDeserializer.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/JsonRpcRequestJsonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/JsonRpcResponseJsonDeserializer.java
+++ b/spring-dsl-jsonrpc/src/main/java/org/springframework/dsl/jsonrpc/support/JsonRpcResponseJsonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/DispatcherJsonRpcHandlerTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/DispatcherJsonRpcHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/ResolvableMethod.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/ResolvableMethod.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractorStrategiesTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/codec/JsonRpcExtractorStrategiesTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/docs/ControllerDocs.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/docs/ControllerDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/HandlerMethodMappingTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/HandlerMethodMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/InvocableHandlerMethodTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/InvocableHandlerMethodTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerMappingTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcRequestMappingHandlerMappingTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcResponseResultResultHandlerTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/result/method/annotation/JsonRpcResponseResultResultHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/DispatcherJsonRpcHandlerTests.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/DispatcherJsonRpcHandlerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockJsonRpcInputMessage.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockJsonRpcInputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockJsonRpcOutputMessage.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockJsonRpcOutputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockServerJsonRpcExchange.java
+++ b/spring-dsl-jsonrpc/src/test/java/org/springframework/dsl/jsonrpc/support/MockServerJsonRpcExchange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspSystemConstants.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspSystemConstants.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspVersionDetector.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspVersionDetector.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/AbstractLspClient.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/AbstractLspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ClientReactorJsonRpcHandlerAdapter.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ClientReactorJsonRpcHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientBuilder.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientResponse.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientResponseBuilder.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/DefaultLspClientResponseBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ExchangeNotificationFunction.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ExchangeNotificationFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ExchangeRequestFunction.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/ExchangeRequestFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/LspClient.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/LspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/LspClientResponse.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/LspClientResponse.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/NettyBoundedLspClient.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/NettyBoundedLspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/NettyTcpClientLspClient.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/NettyTcpClientLspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/config/EnableLanguageClient.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/config/EnableLanguageClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/controller/WindowLanguageClientController.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/client/controller/WindowLanguageClientController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServerException.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServerException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServerFactory.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/LspServerFactory.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/PortInUseException.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/PortInUseException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/DslProperties.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/DslProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/EnableLanguageServer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/EnableLanguageServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/GenericLspConfiguration.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/GenericLspConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspDomainJacksonConfiguration.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspDomainJacksonConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspServerSocketConfiguration.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspServerSocketConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspServerStdioConfiguration.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/config/LspServerStdioConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/controller/RootLanguageServerController.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/controller/RootLanguageServerController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/controller/TextDocumentLanguageServerController.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/controller/TextDocumentLanguageServerController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/DiagnosticSeverityDeserializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/DiagnosticSeverityDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/DiagnosticSeveritySerializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/DiagnosticSeveritySerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MarkupKindDeserializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MarkupKindDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MarkupKindSerializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MarkupKindSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MessageTypeDeserializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MessageTypeDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MessageTypeSerializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/MessageTypeSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/ServerCapabilitiesJsonDeserializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/ServerCapabilitiesJsonDeserializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/ServerCapabilitiesJsonSerializer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/domain/ServerCapabilitiesJsonSerializer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspClientArgumentResolver.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspClientArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspDomainArgumentResolver.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspDomainArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcDecoder.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcDecoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcEncoder.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcEncoder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspSessionState.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/LspSessionState.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/NettyTcpServer.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/NettyTcpServer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/ReactorJsonRpcHandlerAdapter.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/ReactorJsonRpcHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/ReactorJsonRpcOutputMessage.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/ReactorJsonRpcOutputMessage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/RpcHandler.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/RpcHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/RpcJsonRpcHandlerAdapter.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/jsonrpc/RpcJsonRpcHandlerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/JvmLspExiter.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/JvmLspExiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/LspExiter.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/LspExiter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/LspServerRefreshListener.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/LspServerRefreshListener.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/StdioSocketBridge.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/server/support/StdioSocketBridge.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/LspVersionDetectorTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/LspVersionDetectorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/client/DefaultLspClientResponseTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/client/DefaultLspClientResponseTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/docs/ClientDocs.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/docs/ClientDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/docs/ExtensionDocs.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/docs/ExtensionDocs.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/controller/RootLanguageServerControllerTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/controller/RootLanguageServerControllerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/domain/LspDomainJacksonSerializationTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/domain/LspDomainJacksonSerializationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/LspDomainArgumentResolverTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/LspDomainArgumentResolverTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcDecoderTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/LspJsonRpcDecoderTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/NettyTcpServerIntegrationTests.java
+++ b/spring-dsl-lsp-core/src/test/java/org/springframework/dsl/lsp/server/jsonrpc/NettyTcpServerIntegrationTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-lsp-web/src/main/java/org/springframework/dsl/lsp/web/DocumentController.java
+++ b/spring-dsl-lsp-web/src/main/java/org/springframework/dsl/lsp/web/DocumentController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTAntlrParseResultFunction.java
+++ b/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTAntlrParseResultFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageConfiguration.java
+++ b/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageLinter.java
+++ b/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageLinter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageVisitor.java
+++ b/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/DOTLanguageVisitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/EnableDOTLanguage.java
+++ b/spring-dsl-samples/dotdsl/src/main/java/demo/dotdsl/EnableDOTLanguage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/dotdsl/src/test/java/demo/dotdsl/DOTLanguageLinterTests.java
+++ b/spring-dsl-samples/dotdsl/src/test/java/demo/dotdsl/DOTLanguageLinterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcase/src/main/java/demo/showcase/EnableShowcaseFeatures.java
+++ b/spring-dsl-samples/showcase/src/main/java/demo/showcase/EnableShowcaseFeatures.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseCommandsController.java
+++ b/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseCommandsController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseConfiguration.java
+++ b/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseHoverer.java
+++ b/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseHoverer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcaseeditor/src/main/java/demo/showcaseeditor/Application.java
+++ b/spring-dsl-samples/showcaseeditor/src/main/java/demo/showcaseeditor/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcaseeditor/ui/src/app/actions.ts
+++ b/spring-dsl-samples/showcaseeditor/ui/src/app/actions.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/showcaseeditor/ui/src/app/editor-tab-group/editor-tab-group.component.ts
+++ b/spring-dsl-samples/showcaseeditor/ui/src/app/editor-tab-group/editor-tab-group.component.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/EnableSimpleLanguage.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/EnableSimpleLanguage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguage.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageCompletioner.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageCompletioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageConfiguration.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageDslService.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageDslService.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageHoverer.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageHoverer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageLinter.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageLinter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageSymbolizer.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageSymbolizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageCompletionerTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageCompletionerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageHovererTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageHovererTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageLinterTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageLinterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageSymbolizerTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageSymbolizerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledsleditor/src/main/java/demo/simpledsleditor/Application.java
+++ b/spring-dsl-samples/simpledsleditor/src/main/java/demo/simpledsleditor/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledslprocessserver/src/main/java/demo/simpledslprocessserver/Application.java
+++ b/spring-dsl-samples/simpledslprocessserver/src/main/java/demo/simpledslprocessserver/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/simpledslsocketserver/src/main/java/demo/simpledslsocketserver/Application.java
+++ b/spring-dsl-samples/simpledslsocketserver/src/main/java/demo/simpledslsocketserver/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/config.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/config.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-document-service.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-document-service.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-document.service.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-document.service.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.component.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.component.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.component.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.component.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.module.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.module.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.service.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.service.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.service.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-dsl-editor.service.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/base-editor.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/base-editor.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/config.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/config.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-editor.service.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-editor.service.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-editor.service.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-editor.service.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-loader.service.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-loader.service.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-loader.service.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/monaco-loader.service.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/spring-monaco-editor.component.spec.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/spring-monaco-editor.component.spec.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/spring-monaco-editor.component.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/spring-monaco-editor.component.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/types.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/projects/spring-dsl-editor/src/lib/spring-monaco-editor/types.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/src/app/actions.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/src/app/actions.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/src/app/app.component.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/src/app/app.component.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/src/app/app.module.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/src/app/app.module.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/spring-dsl-editor-lib/src/app/editor-tab-group/editor-tab-group.component.ts
+++ b/spring-dsl-samples/spring-dsl-editor-lib/src/app/editor-tab-group/editor-tab-group.component.ts
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/src/main/java/demo/common/SampleRedirectConfiguration.java
+++ b/spring-dsl-samples/src/main/java/demo/common/SampleRedirectConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/EnableWordcheckLanguage.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/EnableWordcheckLanguage.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/FuzzyMatcher.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/FuzzyMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageCompletioner.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageCompletioner.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageConfiguration.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageConfiguration.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageLinter.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageLinter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageRenamer.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageRenamer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageSupport.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageSupport.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageSymbolizer.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageSymbolizer.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckProperties.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckProperties.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageCompletionerTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageCompletionerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageLinterTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageLinterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageRenamerTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageRenamerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageSymbolizerTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageSymbolizerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsleditor/src/main/java/demo/wordcheckdsleditor/Application.java
+++ b/spring-dsl-samples/wordcheckdsleditor/src/main/java/demo/wordcheckdsleditor/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdsleditorservlet/src/main/java/demo/wordcheckdsleditorservlet/Application.java
+++ b/spring-dsl-samples/wordcheckdsleditorservlet/src/main/java/demo/wordcheckdsleditorservlet/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-samples/wordcheckdslprocessserver/src/main/java/demo/wordcheckdslprocessserver/Application.java
+++ b/spring-dsl-samples/wordcheckdslprocessserver/src/main/java/demo/wordcheckdslprocessserver/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/MemberSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/MemberSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Modifier.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Modifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Scope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Scope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Symbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Symbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTable.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTableException.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTableException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTableVisitor.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/SymbolTableVisitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Type.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/Type.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/TypedSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/TypedSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ArrayType.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ArrayType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseModifier.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseModifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseScope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseScope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/BaseSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ClassSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ClassSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/DataAggregateSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/DataAggregateSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FieldSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FieldSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FunctionSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FunctionSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FunctionType.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/FunctionType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/GlobalScope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/GlobalScope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/InvalidType.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/InvalidType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/LocalScope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/LocalScope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/MethodSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/MethodSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/NamedModifier.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/NamedModifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ParameterSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/ParameterSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PointerType.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PointerType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PredefinedScope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PredefinedScope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PrimitiveType.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/PrimitiveType.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/StructSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/StructSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/SymbolWithScope.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/SymbolWithScope.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/TypeAlias.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/TypeAlias.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/VariableSymbol.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/VariableSymbol.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/VisibilityModifier.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/model/VisibilityModifier.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/AbstractSymbolTable.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/AbstractSymbolTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/DefaultSymbolTable.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/DefaultSymbolTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/DocumentSymbolTableVisitor.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/DocumentSymbolTableVisitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/StringTable.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/StringTable.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/Utils.java
+++ b/spring-dsl-symboltable/src/main/java/org/springframework/dsl/symboltable/support/Utils.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/ClassSymbolTests.java
+++ b/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/ClassSymbolTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/DocumentSymbolTableVisitorTests.java
+++ b/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/DocumentSymbolTableVisitorTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/LocalScopeTests.java
+++ b/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/LocalScopeTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/SymbolTableTests.java
+++ b/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/SymbolTableTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/TestSymbolTableVisitor.java
+++ b/spring-dsl-symboltable/src/test/java/org/springframework/dsl/symboltable/TestSymbolTableVisitor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/LspWebSocketConfig.java
+++ b/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/LspWebSocketConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/LspWebSocketHandler.java
+++ b/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/LspWebSocketHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/WebSocketBoundedLspClient.java
+++ b/spring-dsl-websocket-reactive/src/main/java/org/springframework/dsl/lsp/server/websocket/reactive/WebSocketBoundedLspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketConfig.java
+++ b/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketHandler.java
+++ b/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketHandlerConfig.java
+++ b/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/LspServletWebSocketHandlerConfig.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/WebSocketBoundedLspClient.java
+++ b/spring-dsl-websocket-servlet/src/main/java/org/springframework/dsl/lsp/server/websocket/servlet/WebSocketBoundedLspClient.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 402 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0.html with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.html ([https](https://www.apache.org/licenses/LICENSE-2.0.html) result 200).