### PR TITLE
Add DslContext concept

### DIFF
--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrHoverer.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrHoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Hoverer;
 
 import reactor.core.publisher.Mono;
@@ -63,8 +64,8 @@ public class AbstractAntlrHoverer<T> extends AbstractAntlrDslService<T> implemen
 	}
 
 	@Override
-	public Mono<Hover> hover(Document document, Position position) {
-		return getAntlrParseService().parse(document, getAntlrParseResultFunction())
+	public Mono<Hover> hover(DslContext context, Position position) {
+		return getAntlrParseService().parse(context.getDocument(), getAntlrParseResultFunction())
 			.flatMap(r -> r.getHover(position));
 	}
 }

--- a/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrLinter.java
+++ b/spring-dsl-antlr/src/main/java/org/springframework/dsl/antlr/support/AbstractAntlrLinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.dsl.antlr.AntlrParseResult;
 import org.springframework.dsl.antlr.AntlrParseService;
 import org.springframework.dsl.document.Document;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.Linter;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 
@@ -63,8 +64,8 @@ public abstract class AbstractAntlrLinter<T> extends AbstractAntlrDslService<T> 
 	}
 
 	@Override
-	public Flux<ReconcileProblem> lint(Document document) {
-		return getAntlrParseService().parse(document, getAntlrParseResultFunction())
+	public Flux<ReconcileProblem> lint(DslContext context) {
+		return getAntlrParseService().parse(context.getDocument(), getAntlrParseResultFunction())
 			.map(r -> r.getReconcileProblems())
 			.flatMapMany(r -> r.cache());
 	}

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrHovererTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrHovererTests.java
@@ -25,6 +25,7 @@ import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 
 import reactor.core.publisher.Mono;
 
@@ -43,7 +44,7 @@ public class AntlrHovererTests {
 		Test2AntlrParseResultFunction antlrParseResultSupplier = new Test2AntlrParseResultFunction();
 
 		Test2AntlrHoverer hoverer = new Test2AntlrHoverer(antlrParseService, antlrParseResultSupplier);
-		Mono<Hover> hover = hoverer.hover(document, new Position(0, 0));
+		Mono<Hover> hover = hoverer.hover(DslContext.builder().document(document).build(), new Position(0, 0));
 		Hover h = hover.block();
 		assertThat(h, notNullValue());
 		assertThat(h.getRange(), notNullValue());

--- a/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrLinterTests.java
+++ b/spring-dsl-antlr/src/test/java/org/springframework/dsl/antlr/AntlrLinterTests.java
@@ -26,6 +26,7 @@ import org.springframework.dsl.antlr.support.DefaultAntlrParseService;
 import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.domain.Range;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 
 import reactor.core.publisher.Flux;
@@ -47,7 +48,7 @@ public class AntlrLinterTests {
 		Test2AntlrParseResultFunction antlrParseResultSupplier = new Test2AntlrParseResultFunction();
 
 		Test2AntlrLinter linter = new Test2AntlrLinter(antlrParseService, antlrParseResultSupplier);
-		Flux<ReconcileProblem> lint = linter.lint(document);
+		Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 		List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 		assertThat(lints).isEmpty();
 	}
@@ -62,7 +63,7 @@ public class AntlrLinterTests {
 
 		Test2AntlrLinter linter = new Test2AntlrLinter(antlrParseService, antlrParseResultSupplier);
 
-		Flux<ReconcileProblem> lint = linter.lint(document);
+		Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 		List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 		assertThat(lints).hasSize(1);
 		assertThat(lints.get(0).getMessage()).isEqualTo("missing '}' at 'state'");
@@ -79,7 +80,7 @@ public class AntlrLinterTests {
 
 		Test2AntlrLinter linter = new Test2AntlrLinter(antlrParseService, antlrParseResultSupplier);
 
-		Flux<ReconcileProblem> lint = linter.lint(document);
+		Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 		List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 		assertThat(lints).hasSize(2);
 		// TODO: it sucks, antlr don't give correct end position, find if we can fix it
@@ -97,7 +98,7 @@ public class AntlrLinterTests {
 
 		Test2AntlrLinter linter = new Test2AntlrLinter(antlrParseService, antlrParseResultSupplier);
 
-		Flux<ReconcileProblem> lint = linter.lint(document);
+		Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 		List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 		assertThat(lints).hasSize(1);
 		assertThat(lints.get(0).getRange()).isEqualTo(Range.from(0, 0, 0, 0));

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslContext.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/DslContext.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.dsl.service;
+
+import java.util.Map;
+
+import org.springframework.dsl.document.Document;
+import org.springframework.dsl.support.DefaultDslContextBuilder;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Interface which is mostly used to pass dsl related information into
+ * various classes and other intefaces.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public interface DslContext {
+
+    /**
+     * Gets a document for this context.
+     *
+     * @return the document
+     */
+    Document getDocument();
+
+    /**
+     * Gets an attributes for this context.
+     *
+     * @return the attributes
+     */
+    Map<String, Object> getAttributes();
+
+	/**
+	 * Return the context attribute value if present.
+	 *
+	 * @param name the attribute name
+	 * @param <T> the attribute type
+	 * @return the attribute value
+	 */
+	@SuppressWarnings("unchecked")
+	@Nullable
+	default <T> T getAttribute(String name) {
+		return (T) getAttributes().get(name);
+	}
+
+	/**
+	 * Return the context attribute value or if not present raise an
+	 * {@link IllegalArgumentException}.
+	 *
+	 * @param name the attribute name
+	 * @param <T> the attribute type
+	 * @return the attribute value
+	 */
+	default <T> T getRequiredAttribute(String name) {
+		T value = getAttribute(name);
+		Assert.notNull(value, "Required attribute '" + name + "' is missing.");
+		return value;
+	}
+
+    /**
+     * Gets a builder for {@link DslContext}.
+     *
+     * @return the builder
+     */
+    static Builder builder() {
+        return new DefaultDslContextBuilder();
+    }
+
+    interface Builder {
+
+        /**
+         * Sets a {@link Document} instance for this builder.
+         *
+         * @param document the document
+         * @return builder for chaining
+         */
+        Builder document(Document document);
+
+        /**
+         * Sets an attributes for this builder. This will effectively
+         * clear and overrides existing attributes.
+         *
+         * @param attributes the attributes
+         * @return builder for chaining
+         */
+        Builder attributes(Map<String, Object> attributes);
+
+        /**
+         * Set an attribute.
+         *
+         * @param key the attribute key
+         * @param value the attribute valur
+         * @return builder for chaining
+         */
+        Builder attribute(String key, Object value);
+
+        /**
+         * Builds a dsl context.
+         *
+         * @return the built dsl context
+         */
+        DslContext build();
+    }
+}

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/Hoverer.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/Hoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.springframework.dsl.service;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.Position;
 
@@ -34,9 +33,9 @@ public interface Hoverer extends DslService {
 	/**
 	 * Provide hover for a given position in a document.
 	 *
-	 * @param document the  document
+	 * @param context the dsl context
 	 * @param position the position in a document
 	 * @return a {@link Mono} completing as {@link Hover}
 	 */
-	Mono<Hover> hover(Document document, Position position);
+	Mono<Hover> hover(DslContext context, Position position);
 }

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/Renamer.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/Renamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package org.springframework.dsl.service;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.domain.WorkspaceEdit;
 
@@ -33,10 +32,10 @@ public interface Renamer extends DslService {
 	/**
 	 * Provide {@link WorkspaceEdit} for a given {@link Position} with a {@code newName}.
 	 *
-	 * @param document the  document
+	 * @param context the dsl context
 	 * @param position the position in a document
 	 * @param newName the new name
 	 * @return a {@link Mono} completing as {@link WorkspaceEdit}
 	 */
-	Mono<WorkspaceEdit> rename(Document document, Position position, String newName);
+	Mono<WorkspaceEdit> rename(DslContext context, Position position, String newName);
 }

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconciler.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/DefaultReconciler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@ import org.springframework.dsl.domain.DiagnosticSeverity;
 import org.springframework.dsl.domain.PublishDiagnosticsParams;
 import org.springframework.dsl.model.LanguageId;
 import org.springframework.dsl.service.AbstractDslService;
+import org.springframework.dsl.service.DslContext;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -58,13 +59,15 @@ public class DefaultReconciler extends AbstractDslService implements Reconciler 
 	}
 
 	@Override
-	public Flux<PublishDiagnosticsParams> reconcile(Document document) {
+	public Flux<PublishDiagnosticsParams> reconcile(DslContext context) {
+		// TODO: handle null document
+		Document document = context.getDocument();
 		log.debug("Reconciling {}", document);
 
 		return Flux.fromIterable(linters)
 			.filter(linter -> linter.getSupportedLanguageIds().contains(document.languageId()))
 			.map(linter -> {
-				return linter.lint(document);
+				return linter.lint(context);
 			})
 			.flatMap(r -> r)
 			.filter(p -> getDiagnosticSeverity(p) != null)

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Linter.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Linter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,13 @@
 package org.springframework.dsl.service.reconcile;
 
 import org.springframework.dsl.document.Document;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.DslService;
 
 import reactor.core.publisher.Flux;
 
 /**
- * Strategy interface for linting a {@link Document}.
+ * Strategy interface for linting a {@link Document} from a {@link DslContext}.
  *
  * @author Kris De Volder
  * @author Janne Valkealahti
@@ -30,10 +31,10 @@ import reactor.core.publisher.Flux;
 public interface Linter extends DslService {
 
 	/**
-	 * Reconcile a {@link Document}.
+	 * Reconcile a document from a context.
 	 *
-	 * @param document the document to reconcile
+	 * @param context the dsl context
 	 * @return a {@link Flux} of {@link ReconcileProblem}s
 	 */
-	Flux<ReconcileProblem> lint(Document document);
+	Flux<ReconcileProblem> lint(DslContext context);
 }

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Reconciler.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/service/reconcile/Reconciler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.springframework.dsl.service.reconcile;
 
 import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.PublishDiagnosticsParams;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.DslService;
 
 import reactor.core.publisher.Flux;
@@ -38,8 +39,8 @@ public interface Reconciler extends DslService {
 	/**
 	 * Reconcile a {@link Document} and return {@link Mono} for completion.
 	 *
-	 * @param document the document
+	 * @param context the dsl context
 	 * @return a {@link Mono} indicating reconcile operation completion
 	 */
-	Flux<PublishDiagnosticsParams> reconcile(Document document);
+	Flux<PublishDiagnosticsParams> reconcile(DslContext context);
 }

--- a/spring-dsl-core/src/main/java/org/springframework/dsl/support/DefaultDslContextBuilder.java
+++ b/spring-dsl-core/src/main/java/org/springframework/dsl/support/DefaultDslContextBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.dsl.support;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.dsl.document.Document;
+import org.springframework.dsl.service.DslContext;
+import org.springframework.dsl.service.DslContext.Builder;
+
+/**
+ * Default implementation of a {@link DslContext.Builder}.
+ *
+ * @author Janne Valkealahti
+ *
+ */
+public class DefaultDslContextBuilder implements DslContext.Builder {
+
+    private Document document;
+    private Map<String, Object> attributes = new HashMap<>();
+
+    @Override
+    public DslContext.Builder document(Document document) {
+        this.document = document;
+        return this;
+    }
+
+    @Override
+    public Builder attributes(Map<String, Object> attributes) {
+        this.attributes = attributes != null ? attributes : new HashMap<>();
+        return this;
+    }
+
+    @Override
+    public Builder attribute(String key, Object value) {
+        this.attributes.put(key, value);
+        return this;
+    }
+
+    @Override
+    public DslContext build() {
+        return new DefaultDslContext(document, attributes);
+    }
+
+    private static class DefaultDslContext implements DslContext {
+
+        private final Document document;
+        private final Map<String, Object> attributes;
+
+        DefaultDslContext(Document document, Map<String, Object> attributes) {
+            this.document = document;
+            this.attributes = attributes;
+        }
+
+        @Override
+        public Document getDocument() {
+            return document;
+        }
+
+        @Override
+        public Map<String, Object> getAttributes() {
+            return attributes;
+        }
+    }
+}

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/HoverDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/HoverDocs.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.dsl.docs;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.Position;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Hoverer;
 
 import reactor.core.publisher.Mono;
@@ -28,7 +28,7 @@ public class HoverDocs {
 
 		@Override
 // tag::snippet1[]
-		Mono<Hover> hover(Document document, Position position);
+		Mono<Hover> hover(DslContext context, Position position);
 // end::snippet1[]
 	}
 

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/ReconcileDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/ReconcileDocs.java
@@ -15,8 +15,8 @@
  */
 package org.springframework.dsl.docs;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.PublishDiagnosticsParams;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.Linter;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 import org.springframework.dsl.service.reconcile.Reconciler;
@@ -29,7 +29,7 @@ public class ReconcileDocs {
 
 		@Override
 // tag::snippet1[]
-		Flux<ReconcileProblem> lint(Document document);
+		Flux<ReconcileProblem> lint(DslContext context);
 // end::snippet1[]
 	}
 
@@ -37,7 +37,7 @@ public class ReconcileDocs {
 
 		@Override
 // tag::snippet2[]
-		Flux<PublishDiagnosticsParams> reconcile(Document document);
+		Flux<PublishDiagnosticsParams> reconcile(DslContext context);
 // end::snippet2[]
 	}
 }

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/docs/RenameDocs.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/docs/RenameDocs.java
@@ -15,9 +15,9 @@
  */
 package org.springframework.dsl.docs;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.domain.WorkspaceEdit;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Renamer;
 
 import reactor.core.publisher.Mono;
@@ -28,7 +28,7 @@ public class RenameDocs {
 
 		@Override
 // tag::snippet1[]
-		Mono<WorkspaceEdit> rename(Document document, Position position, String newName);
+		Mono<WorkspaceEdit> rename(DslContext context, Position position, String newName);
 // end::snippet1[]
 	}
 }

--- a/spring-dsl-core/src/test/java/org/springframework/dsl/service/reconcile/DefaultReconcilerTests.java
+++ b/spring-dsl-core/src/test/java/org/springframework/dsl/service/reconcile/DefaultReconcilerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.junit.Test;
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.domain.PublishDiagnosticsParams;
 import org.springframework.dsl.domain.Range;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 
 import reactor.core.publisher.Flux;
 
@@ -48,7 +48,7 @@ public class DefaultReconcilerTests {
 			}
 
 			@Override
-			public Flux<ReconcileProblem> lint(Document document) {
+			public Flux<ReconcileProblem> lint(DslContext context) {
 				return Flux.just(new ReconcileProblem() {
 
 					@Override
@@ -71,7 +71,7 @@ public class DefaultReconcilerTests {
 
 		DefaultReconciler reconciler = new DefaultReconciler(Arrays.asList(linter));
 		TextDocument document = new TextDocument("", LanguageId.TXT, 0, "");
-		Flux<PublishDiagnosticsParams> reconcile = reconciler.reconcile(document);
+		Flux<PublishDiagnosticsParams> reconcile = reconciler.reconcile(DslContext.builder().document(document).build());
 		assertThat(reconcile).isNotNull();
 		List<PublishDiagnosticsParams> lints = reconcile.toStream().collect(Collectors.toList());
 		assertThat(lints).hasSize(1);

--- a/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspSystemConstants.java
+++ b/spring-dsl-lsp-core/src/main/java/org/springframework/dsl/lsp/LspSystemConstants.java
@@ -44,4 +44,9 @@ public abstract class LspSystemConstants {
 	 * Session attribute containing added lsp client
 	 */
 	public final static String SESSION_ATTRIBUTE_LSP_CLIENT = "lspClient";
+
+	/**
+	 * Context session attribute containing added json rpc session
+	 */
+	public final static String CONTEXT_SESSION_ATTRIBUTE = "jsonRpcSession";
 }

--- a/spring-dsl-samples/dotdsl/src/test/java/demo/dotdsl/DOTLanguageLinterTests.java
+++ b/spring-dsl-samples/dotdsl/src/test/java/demo/dotdsl/DOTLanguageLinterTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.dsl.document.TextDocument;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 
 import reactor.core.publisher.Flux;
@@ -50,7 +51,7 @@ public class DOTLanguageLinterTests {
 			.run((context) -> {
 				DOTLanguageLinter linter = context.getBean(DOTLanguageLinter.class);
 				TextDocument document = new TextDocument("", DOTLanguageConfiguration.LANGUAGEID, 0, "graph xxx {}");
-				Flux<ReconcileProblem> lint = linter.lint(document);
+				Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 				List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 				assertThat(lints).isEmpty();
 			});
@@ -59,7 +60,7 @@ public class DOTLanguageLinterTests {
 			.run((context) -> {
 				DOTLanguageLinter linter = context.getBean(DOTLanguageLinter.class);
 				TextDocument document = new TextDocument("", DOTLanguageConfiguration.LANGUAGEID, 0, "");
-				Flux<ReconcileProblem> lint = linter.lint(document);
+				Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 				List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 				assertThat(lints).hasSize(1);
 				assertThat(lints.get(0).getMessage()).contains("expecting", "GRAPH", "DIGRAPH");
@@ -69,7 +70,7 @@ public class DOTLanguageLinterTests {
 			.run((context) -> {
 				DOTLanguageLinter linter = context.getBean(DOTLanguageLinter.class);
 				TextDocument document = new TextDocument("", DOTLanguageConfiguration.LANGUAGEID, 0, "xxx");
-				Flux<ReconcileProblem> lint = linter.lint(document);
+				Flux<ReconcileProblem> lint = linter.lint(DslContext.builder().document(document).build());
 				List<ReconcileProblem> lints = lint.toStream().collect(Collectors.toList());
 				assertThat(lints).hasSize(1);
 				assertThat(lints.get(0).getMessage()).contains("expecting", "GRAPH", "DIGRAPH");

--- a/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseHoverer.java
+++ b/spring-dsl-samples/showcase/src/main/java/demo/showcase/ShowcaseHoverer.java
@@ -17,12 +17,12 @@ package demo.showcase;
 
 import java.util.Arrays;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.MarkupKind;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.model.LanguageId;
 import org.springframework.dsl.service.AbstractDslService;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Hoverer;
 
 import reactor.core.publisher.Mono;
@@ -41,7 +41,7 @@ public class ShowcaseHoverer extends AbstractDslService implements Hoverer {
 	}
 
 	@Override
-	public Mono<Hover> hover(Document document, Position position) {
+	public Mono<Hover> hover(DslContext context, Position position) {
 		return Mono.defer(() ->
 			Mono.just(Hover.hover()
 				.contents()

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageHoverer.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageHoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package demo.simpledsl;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.MarkupKind;
 import org.springframework.dsl.domain.Position;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Hoverer;
 
 import demo.simpledsl.SimpleLanguage.Token;
@@ -35,7 +35,7 @@ import reactor.core.publisher.Mono;
 public class SimpleLanguageHoverer extends SimpleLanguageDslService implements Hoverer {
 
 	@Override
-	public Mono<Hover> hover(Document document, Position position) {
+	public Mono<Hover> hover(DslContext context, Position position) {
 		// we're getting a request to provide a hover in a document
 		// for a specific position. from a document, request a token
 		// for this particular position and return information about
@@ -44,7 +44,7 @@ public class SimpleLanguageHoverer extends SimpleLanguageDslService implements H
 		// operation will happen when demand for it is requested.
 
 		return Mono.defer(() -> {
-			SimpleLanguage simpleLanguage = SimpleLanguage.build(document);
+			SimpleLanguage simpleLanguage = SimpleLanguage.build(context.getDocument());
 			Token token = simpleLanguage.getToken(position);
 			if (token != null && token.getType() != null) {
 				Hover hover = Hover.hover()

--- a/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageLinter.java
+++ b/spring-dsl-samples/simpledsl/src/main/java/demo/simpledsl/SimpleLanguageLinter.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.dsl.document.Document;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.DefaultReconcileProblem;
 import org.springframework.dsl.service.reconcile.Linter;
 import org.springframework.dsl.service.reconcile.ProblemSeverity;
@@ -39,9 +40,9 @@ import reactor.core.publisher.Flux;
 public class SimpleLanguageLinter extends SimpleLanguageDslService implements Linter {
 
 	@Override
-	public Flux<ReconcileProblem> lint(Document document) {
+	public Flux<ReconcileProblem> lint(DslContext context) {
 		return Flux.defer(() -> {
-			return Flux.fromIterable(lintProblems(document));
+			return Flux.fromIterable(lintProblems(context.getDocument()));
 		});
 	}
 

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageHovererTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageHovererTests.java
@@ -23,6 +23,7 @@ import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.domain.Hover;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 
 import reactor.core.publisher.Mono;
 
@@ -40,7 +41,7 @@ public class SimpleLanguageHovererTests {
 	public void testHovers() {
 		Document document = new TextDocument("", LanguageId.TXT, 0, SimpleLanguageTests.content1);
 
-		Mono<Hover> hover = hoverer.hover(document, new Position(0, 1));
+		Mono<Hover> hover = hoverer.hover(DslContext.builder().document(document).build(), new Position(0, 1));
 		assertThat(hover).isNotNull();
 		assertThat(hover.block()).isNotNull();
 		assertThat(hover.block().getContents()).isNotNull();
@@ -51,7 +52,7 @@ public class SimpleLanguageHovererTests {
 	public void testInvalidToken() {
 		Document document = new TextDocument("", LanguageId.TXT, 0, SimpleLanguageTests.content8);
 
-		Mono<Hover> hover = hoverer.hover(document, new Position(0, 1));
+		Mono<Hover> hover = hoverer.hover(DslContext.builder().document(document).build(), new Position(0, 1));
 		assertThat(hover).isNotNull();
 		assertThat(hover.block()).isNull();
 	}

--- a/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageLinterTests.java
+++ b/spring-dsl-samples/simpledsl/src/test/java/demo/simpledsl/SimpleLanguageLinterTests.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.springframework.dsl.document.Document;
 import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 
 /**
@@ -39,23 +40,23 @@ public class SimpleLanguageLinterTests {
 	@Test
 	public void testLints() {
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content1);
-		List<ReconcileProblem> problems = linter.lint(document).toStream().collect(Collectors.toList());
+		List<ReconcileProblem> problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).isEmpty();
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content2);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).isEmpty();
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content3);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).isEmpty();
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content4);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).isEmpty();
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content5);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 		ReconcileProblem problem = problems.get(0);
 		assertThat(problem.getRange().getStart().getLine()).isEqualTo(0);
@@ -67,22 +68,22 @@ public class SimpleLanguageLinterTests {
 	@Test
 	public void testUnknownKeyType() {
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content8);
-		List<ReconcileProblem> problems = linter.lint(document).toStream().collect(Collectors.toList());
+		List<ReconcileProblem> problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 	}
 
 	@Test
 	public void testWrongValueType() {
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content7);
-		List<ReconcileProblem> problems = linter.lint(document).toStream().collect(Collectors.toList());
+		List<ReconcileProblem> problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content9);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, SimpleLanguageTests.content10);
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 	}
 }

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageLinter.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageLinter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package demo.wordcheckdsl;
 
 import java.util.regex.Pattern;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.document.DocumentRegion;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.DefaultReconcileProblem;
 import org.springframework.dsl.service.reconcile.Linter;
 import org.springframework.dsl.service.reconcile.ProblemSeverity;
@@ -41,8 +41,8 @@ public class WordcheckLanguageLinter extends WordcheckLanguageSupport implements
 	private static final Pattern SPACE = Pattern.compile("[^\\w]+");
 
 	@Override
-	public Flux<ReconcileProblem> lint(Document document) {
-		return Flux.defer(() -> Flux.fromArray(new DocumentRegion(document).split(SPACE)))
+	public Flux<ReconcileProblem> lint(DslContext context) {
+		return Flux.defer(() -> Flux.fromArray(new DocumentRegion(context.getDocument()).split(SPACE)))
 				.filter(w -> w.length() > 0)
 				.filter(w -> !getProperties().getWords().contains(w.toString()))
 				.map(this::problem);

--- a/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageRenamer.java
+++ b/spring-dsl-samples/wordcheckdsl/src/main/java/demo/wordcheckdsl/WordcheckLanguageRenamer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,11 @@
  */
 package demo.wordcheckdsl;
 
-import org.springframework.dsl.document.Document;
 import org.springframework.dsl.domain.DocumentSymbol;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.domain.TextEdit;
 import org.springframework.dsl.domain.WorkspaceEdit;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.Renamer;
 import org.springframework.dsl.service.symbol.Symbolizer;
 import org.springframework.dsl.support.DslUtils;
@@ -48,8 +48,8 @@ public class WordcheckLanguageRenamer extends WordcheckLanguageSupport implement
 	}
 
 	@Override
-	public Mono<WorkspaceEdit> rename(Document document, Position position, String newName) {
-		Flux<DocumentSymbol> symbols = symbolizer.symbolize(document).documentSymbols();
+	public Mono<WorkspaceEdit> rename(DslContext context, Position position, String newName) {
+		Flux<DocumentSymbol> symbols = symbolizer.symbolize(context.getDocument()).documentSymbols();
 		Mono<DocumentSymbol> symbol = symbols
 			.filter(s -> DslUtils.isPositionInRange(position, s.getRange())).next();
 		return symbols
@@ -61,7 +61,7 @@ public class WordcheckLanguageRenamer extends WordcheckLanguageSupport implement
 			.collectList()
 			.map(list -> {
 				return WorkspaceEdit.workspaceEdit()
-					.changes(document.uri(), list)
+					.changes(context.getDocument().uri(), list)
 					.build();
 			});
 	}

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageLinterTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageLinterTests.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.springframework.dsl.document.Document;
 import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 import org.springframework.dsl.service.reconcile.ReconcileProblem;
 
 /**
@@ -41,23 +42,23 @@ public class WordcheckLanguageLinterTests {
 		linter.getProperties().setWords(Arrays.asList("jack", "is", "a", "dull", "boy"));
 
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, "");
-		List<ReconcileProblem> problems = linter.lint(document).toStream().collect(Collectors.toList());
+		List<ReconcileProblem> problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).isEmpty();
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, "xxx");
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack is a dull boy");
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(0);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack is a xxx dull xxx boy");
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(2);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack is a dull boy\nxxx\njack is a dull boy");
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(1);
 		ReconcileProblem problem = problems.get(0);
 		assertThat(problem.getRange().getStart().getLine()).isEqualTo(1);
@@ -66,7 +67,7 @@ public class WordcheckLanguageLinterTests {
 		assertThat(problem.getRange().getEnd().getCharacter()).isEqualTo(3);
 
 		document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack\nxxx\njack\nddd\njack");
-		problems = linter.lint(document).toStream().collect(Collectors.toList());
+		problems = linter.lint(DslContext.builder().document(document).build()).toStream().collect(Collectors.toList());
 		assertThat(problems).hasSize(2);
 		problem = problems.get(0);
 		assertThat(problem.getRange().getStart().getLine()).isEqualTo(1);

--- a/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageRenamerTests.java
+++ b/spring-dsl-samples/wordcheckdsl/src/test/java/demo/wordcheckdsl/WordcheckLanguageRenamerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.dsl.document.TextDocument;
 import org.springframework.dsl.domain.Position;
 import org.springframework.dsl.domain.WorkspaceEdit;
 import org.springframework.dsl.model.LanguageId;
+import org.springframework.dsl.service.DslContext;
 
 /**
  * Tests for {@link WordcheckLanguageRenamer}.
@@ -41,7 +42,8 @@ public class WordcheckLanguageRenamerTests {
 		WordcheckLanguageRenamer renamer = new WordcheckLanguageRenamer(symbolizer);
 		renamer.getProperties().setWords(Arrays.asList("jack", "is", "a", "dull", "boy"));
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack is a dull boy");
-		WorkspaceEdit workspaceEdit = renamer.rename(document, Position.from(0, 0), "xxx").block();
+		WorkspaceEdit workspaceEdit = renamer
+				.rename(DslContext.builder().document(document).build(), Position.from(0, 0), "xxx").block();
 		WorkspaceEdit expect = WorkspaceEdit.workspaceEdit()
 			.changes("fakeuri")
 				.newText("xxx")
@@ -65,7 +67,8 @@ public class WordcheckLanguageRenamerTests {
 		WordcheckLanguageRenamer renamer = new WordcheckLanguageRenamer(symbolizer);
 		renamer.getProperties().setWords(Arrays.asList("jack", "is", "a", "dull", "boy"));
 		Document document = new TextDocument("fakeuri", LanguageId.TXT, 0, "jack is a dull boy");
-		WorkspaceEdit workspaceEdit = renamer.rename(document, Position.from(0, 6), "xxx").block();
+		WorkspaceEdit workspaceEdit = renamer
+				.rename(DslContext.builder().document(document).build(), Position.from(0, 6), "xxx").block();
 		WorkspaceEdit expect = WorkspaceEdit.workspaceEdit()
 			.changes("fakeuri")
 				.newText("xxx")


### PR DESCRIPTION
- DslContext wraps a Document and additional attribute data for
  generic layer of passing data to a methods, i.e. session info.
- Change all core interfaces to use it.
- Fixes #17